### PR TITLE
fix(error-nightly): trait  is not implemented for `&&[std::string::String]`

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -32,7 +32,7 @@ pub fn run_args(cmd: &str, args: &[String], shell: bool) -> Result<(Output)> {
 
     if args.len() > 0 {
         if !shell {
-            output = try!(Command::new(cmd).args(&args).output());
+            output = try!(Command::new(cmd).args(args.iter()).output());
         } else {
             let mut arg_string = String::new();
             arg_string = arg_string + cmd + " ";


### PR DESCRIPTION
Fixes the error within the pull request's title for `rustc 1.17.0-nightly (c49d10207 2017-02-07)`