### PR TITLE
fix signed vs unsigned char compilation error

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -49,7 +49,7 @@ pub fn hostname() -> Result<String> {
     match err {
         0 => {
             let slice = unsafe {
-                CStr::from_ptr(ptr as *const i8)
+                CStr::from_ptr(ptr as *const libc::c_char)
             };
             let s = try!(slice.to_str());
             Ok(s.to_string())


### PR DESCRIPTION
It would appear that C's char type has a different signedness on
armv7-unknown-linux-gnueabihf.

This fixes a bug mentioned in #1.

Associated error:
    error[E0308]: mismatched types
      --> src/system.rs:52:32
       |
    52 |                 CStr::from_ptr(ptr as *const i8)
       |                                ^^^^^^^^^^^^^^^^ expected u8, found i8
       |
       = note: expected type `*const u8`
                  found type `*const i8`
       = help: here are some functions which might fulfill your needs:
               - .offset(...)
               - .wrapping_offset(...)