### PR TITLE
Removed superfluous borrow of args at line 35

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -32,7 +32,7 @@ pub fn run_args(cmd: &str, args: &[String], shell: bool) -> Result<(Output)> {
 
     if args.len() > 0 {
         if !shell {
-            output = try!(Command::new(cmd).args(&args).output());
+            output = try!(Command::new(cmd).args(args).output());
         } else {
             let mut arg_string = String::new();
             arg_string = arg_string + cmd + " ";


### PR DESCRIPTION
The signature for `Command::args` is

```
fn args<I, S>(&mut self, args: I) -> &mut Command 
where I: IntoIterator<Item=S>, S: AsRef<OsStr>
```

The type of `args` as an argument to the function `run_args` is `&[String]`. The `IntoIterator` bound is covered by the `IntoIterator` implementation for `&[T]`, while the `AsRef<OsStr>` is readily implemented for `String`.

Reborrowing `args` yields a value of the type `&&[String]` which does not have an implementation of `IntoIterator`, since `IntoIterator` is not carried across `Defer`.

Borrow is also superfluous as `&T` is `Copy`.

This is what causes the bug reported [here](https://github.com/lambdastackio/lsio/issues/3), which for unknown reasons does not replicate on the `nightly-x86_64-apple-darwin updated - rustc 1.17.0-nightly (3da40237e 2017-03-24)` compiler.

Failure to replicate is possibly due to a bug; according to rust's semantics reborrowing `args` should be an error.

Minimal example of error:

```
fn main() {
  let args : &[String] = [];
  std::process::Command::new("ls").args(args);
  std::process::Command::new("ls").args(&args);
}
```