### PR TITLE
Remove deprecated duplicate macro exports

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -45,23 +45,6 @@ macro_rules! print_color {
     };
 }
 
-
-/// print_color! with quiet option.
-///
-#[macro_export]
-macro_rules! println_color_quiet {
-    ($quiet:expr, $color:expr, $($arg:tt)*) => {
-        {
-            if !$quiet {
-                let mut t = term::stderr().unwrap();
-                t.fg($color).unwrap();
-                print!($($arg)*);
-                t.reset().unwrap();
-            }
-        }
-    };
-}
-
 /// println! with a specific color.
 ///
 #[macro_export]


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/50143 for more details.