### PR TITLE
Fix compilation error because of duplicate macro decl

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -45,11 +45,10 @@ macro_rules! print_color {
     };
 }
 
-
 /// print_color! with quiet option.
 ///
 #[macro_export]
-macro_rules! println_color_quiet {
+macro_rules! print_color_quiet {
     ($quiet:expr, $color:expr, $($arg:tt)*) => {
         {
             if !$quiet {


### PR DESCRIPTION
macro println_color_quiet was declared twice, because one of those
declarations should be print_color_quiet

```shell
manos ~/Downloads/lsio % cargo lbuild
   Compiling lsio v0.1.18 (/Users/manos/Downloads/lsio)
error[E0428]: the name `println_color_quiet` is defined multiple times
   --> src/macros.rs:100:1
    |
52  | macro_rules! println_color_quiet {
    | -------------------------------- previous definition of the macro `println_color_quiet` here
...
100 | macro_rules! println_color_quiet {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `println_color_quiet` redefined here
    |
    = note: `println_color_quiet` must be defined only once in the macro namespace of this module

error: could not compile `lsio` due to 2 previous errors; 12 warnings emitted
```